### PR TITLE
CIで使用するUnityのテスト

### DIFF
--- a/.github/workflows/BuidAllPlatform.yml
+++ b/.github/workflows/BuidAllPlatform.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         unityVersion:
-          - 2019.4.3f1
+          - 2019.3.5f1
         targetPlatform:
           - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
           - StandaloneWindows # Build a Windows standalone.

--- a/.github/workflows/BuidAllPlatform.yml
+++ b/.github/workflows/BuidAllPlatform.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         unityVersion:
-          - 2019.3.5f1
+          - 2019.4.0f1
         targetPlatform:
           - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
           - StandaloneWindows # Build a Windows standalone.

--- a/.github/workflows/BuidAllPlatform.yml
+++ b/.github/workflows/BuidAllPlatform.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         unityVersion:
-          - 2019.4.0f1
+          - 2019.3.5f1
         targetPlatform:
           - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
           - StandaloneWindows # Build a Windows standalone.

--- a/.github/workflows/BuidAllPlatform.yml
+++ b/.github/workflows/BuidAllPlatform.yml
@@ -65,7 +65,7 @@ jobs:
             Library-
       
       - name: Build Binary
-        uses: webbertakken/unity-builder@v0.11
+        uses: webbertakken/unity-builder@master
         with:
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}

--- a/.github/workflows/TestRunner.yml
+++ b/.github/workflows/TestRunner.yml
@@ -28,7 +28,7 @@ jobs:
           key: Library-${{ matrix.projectPath }}
           restore-keys: |
             Library-
-      - uses: webbertakken/unity-test-runner@v1.4
+      - uses: webbertakken/unity-test-runner@master
         id: tests
         with:
           unityVersion: ${{ matrix.unityVersion }}

--- a/.github/workflows/TestRunner.yml
+++ b/.github/workflows/TestRunner.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         unityVersion:
-          - 2019.4.3f1
+          - 2019.3.5f1
         testMode:
           - playmode
           - editmode

--- a/.github/workflows/TestRunner.yml
+++ b/.github/workflows/TestRunner.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         unityVersion:
-          - 2019.4.0f1
+          - 2019.3.5f1
         testMode:
           - playmode
           - editmode

--- a/.github/workflows/TestRunner.yml
+++ b/.github/workflows/TestRunner.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         unityVersion:
-          - 2019.3.5f1
+          - 2019.4.0f1
         testMode:
           - playmode
           - editmode


### PR DESCRIPTION
+ 2019.4.0f1以降のバージョンが使えない
  + 原因不明
  + とりあえずCIは2019.3,5f1で運用
  + 2019.4.4f1(LTS)にアップグレードしたい